### PR TITLE
Add shell setup using tea

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ This is the companion repository for the *KERI Tutorial Series: Treasure Hunting
 | python.org    | ^3.11.2  |
 | rust-lang.org | ^1.65.0  |
 
-If you don't have [tea](tea.xyz) already installed,
-run the following in this directory to start a temporary shell with those basic tools: `sh <(curl tea.xyz) -E sh`
+One approach is to run the following command in this directory,
+which will start a temporary shell with those basic tools
+but will not make permanent changes to your machine: `sh <(curl tea.xyz) -E sh`
+(We recommend installing [tea](tea.xyz) but it is not necessary.)
 
 - [kaslcred](https://pypi.org/project/kaslcred/) for generation of schemas
 - [vLEI server (vLEI-server)](https://github.com/WebOfTrust/vLEI)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ This is the companion repository for the *KERI Tutorial Series: Treasure Hunting
 
 ## Dependencies
 
+| Project       | Version  |
+|---------------|----------|
+| libsodium.org | ^1.0.18  |
+| python.org    | ^3.11.2  |
+| rust-lang.org | ^1.65.0  |
+
+If you don't have [tea](tea.xyz) already installed,
+run the following in this directory to start a temporary shell with those basic tools: `sh <(curl tea.xyz) -E sh`
+
 - [kaslcred](https://pypi.org/project/kaslcred/) for generation of schemas
 - [vLEI server (vLEI-server)](https://github.com/WebOfTrust/vLEI)
 - [sally](https://github.com/kentbull/sally)


### PR DESCRIPTION
I used tea to set up this environment and successfully run the workflow.sh script; tea looks at the README at the table inside a "Dependencies" section to know what tools & versions to install.

Another way to experiment with tea is to explicitly tell it which tools you want on the command line. In this case:
`sh <(curl tea.xyz) +rust-lang.org +python.org +libsodium.org sh`

You can install tea, too, but the commands here just make a sandbox environment; neither one actually installs tea permanently on your system.